### PR TITLE
Делает синтаксис .view.tree более строгим

### DIFF
--- a/view/tree2/class/props.test.ts
+++ b/view/tree2/class/props.test.ts
@@ -25,12 +25,12 @@ namespace $.$$ {
 
 			const dest = `
 				query? \\
-				clear?event null
+				clear? null
 				Query $mol_string value? <=> query?
 				Suggest_label $mol_dimmer
 					needle <= query?
 					key * escape? <=> clear?
-				Clear $mol_button_minor click?event <=> clear?event
+				Clear $mol_button_minor click? <=> clear?
 			`
 			const res = normalize($, src, dest)
 			$mol_assert_equal(res.input, res.output)
@@ -54,10 +54,10 @@ namespace $.$$ {
 			const dest = `
 				Close_icon ${d}mol_icon_cross
 				Title ${d}mol_view sub / <= title
-				close?event null
+				close? null
 				Close ${d}mol_button
 					title \\close
-					click?event <=> close?event
+					click? <=> close?
 				title @ \\title
 				sub2 / <= Close_icon
 				sub /
@@ -109,7 +109,7 @@ namespace $.$$ {
 			const dest = `
 				clear? = Suggest_label clear?
 				Suggest_label $mol_dimmer clear? => clear?
-				Clear $mol_button_minor click?e <=> clear?e
+				Clear $mol_button_minor click? <=> clear?
 			`
 
 			const res = normalize($, src, dest)
@@ -130,7 +130,7 @@ namespace $.$$ {
 				`Need an equal default values at \`/mol/view/tree2/class/props.test.ts#4:16/5\` vs \`/mol/view/tree2/class/props.test.ts#6:23/11\`
 <=>
 /mol/view/tree2/class/props.test.ts#6:19/3
-click?event
+click?
 /mol/view/tree2/class/props.test.ts#6:7/11
 $mol_button_minor
 /mol/view/tree2/class/props.test.ts#5:12/17

--- a/view/tree2/class/props.ts
+++ b/view/tree2/class/props.ts
@@ -97,25 +97,20 @@ namespace $ {
 	}
 
 	const is_writable = (input: $mol_tree2) => input.type.includes('?')
-	function ensure_writable(this: $, input?: $mol_tree2) {
-		if (input && !is_writable(input)) this.$mol_fail(err`Expected writable at ${input.span}`)
-	}
-	function ensure_readonly(this: $, input?: $mol_tree2) {
-		if (input && is_writable(input)) this.$mol_fail(err`Expected readonly at ${input.span}`)
-	}
 	function bindings(this: $, left: $mol_tree2) {
 		const operator = left.kids[0]
+		const right = operator?.kids[0]
 		switch (operator?.type) {
 			case '<=>':
-				ensure_writable.call(this, left)
-				ensure_writable.call(this, operator.kids[0])
+				if (!is_writable(left)) this.$mol_fail(err`Expected writable at ${left.span}`)
+				if (right && !is_writable(right)) this.$mol_fail(err`Expected writable at ${right.span}`)
 				break
 			case '=>':
-				const right = operator.kids[0]
-				if (right && is_writable(left) !== is_writable(right)) this.$mol_fail(err`Left and right operands are not compatible at ${operator.span}`)
+				if (right && is_writable(left) !== is_writable(right))
+					this.$mol_fail(err`Left and right operands are not compatible at ${operator.span}`)
 				break
 			case '<=':
-				ensure_readonly.call(this, left)
+				this.$mol_fail(err`Expected readonly at ${left.span}`)
 				break
 		}
 	}

--- a/view/tree2/class/props.ts
+++ b/view/tree2/class/props.ts
@@ -2,6 +2,8 @@ namespace $ {
 	const err = $mol_view_tree2_error_str
 	type Context = { factory?: $mol_tree2 }
 
+	const is_writable = (input: $mol_tree2) => input.type.includes('?')
+
 	export function $mol_view_tree2_class_props(
 		this: $,
 		klass : $mol_tree2,
@@ -42,8 +44,6 @@ namespace $ {
 
 			return [ operator.clone([ prop.clone([]) ]) ]
 		}
-
-		const is_writable = (input: $mol_tree2) => input.type.includes('?')
 
 		const props_root = props.hack({
 			'<=': upper,

--- a/view/tree2/class/props.ts
+++ b/view/tree2/class/props.ts
@@ -43,6 +43,8 @@ namespace $ {
 			return [ operator.clone([ prop.clone([]) ]) ]
 		}
 
+		const is_writable = (input: $mol_tree2) => input.type.includes('?')
+
 		const props_root = props.hack({
 			'<=': upper,
 
@@ -54,7 +56,6 @@ namespace $ {
 			},
 
 			'': (left, belt, context) => {
-				bindings.call(this, left)
 
 				let right
 				const operator = left.kids[0]
@@ -63,6 +64,8 @@ namespace $ {
 					right = operator.kids[0]
 					if (! right) this.$mol_fail(err`Need a child ${operator.span}`)
 					if (! context.factory) this.$mol_fail(err`Need a parent ${left.span}`)
+					if ( is_writable( left ) !== is_writable( right ) )
+						this.$mol_fail(err`Left and right operands are not compatible at ${operator.span}`)
 
 					add_inner(right.clone([
 						right.struct('=', [
@@ -72,6 +75,13 @@ namespace $ {
 							),
 						]),
 					]))
+				} else if (operator?.type === "<=>") {
+					const right = operator.kids[0]
+					if (! right) this.$mol_fail(err`Need a child ${operator.span}`)
+					if (! is_writable(left)) this.$mol_fail(err`Expected writable at ${left.span}`)
+					if (! is_writable(right)) this.$mol_fail(err`Expected writable at ${right.span}`)
+				} else if (operator?.type === "<=" && is_writable(left)) {
+					this.$mol_fail(err`Expected readonly at ${left.span}`)
 				}
 
 				if (right) context = { factory: right.clone([]) }
@@ -90,24 +100,4 @@ namespace $ {
 		
 		return Object.values(props_inner)
 	}
-
-	const is_writable = (input: $mol_tree2) => input.type.includes('?')
-	function bindings(this: $, left: $mol_tree2) {
-		const operator = left.kids[0]
-		const right = operator?.kids[0]
-		switch (operator?.type) {
-			case '<=>':
-				if (!is_writable(left)) this.$mol_fail(err`Expected writable at ${left.span}`)
-				if (right && !is_writable(right)) this.$mol_fail(err`Expected writable at ${right.span}`)
-				break
-			case '=>':
-				if (right && is_writable(left) !== is_writable(right))
-					this.$mol_fail(err`Left and right operands are not compatible at ${operator.span}`)
-				break
-			case '<=':
-				this.$mol_fail(err`Expected readonly at ${left.span}`)
-				break
-		}
-	}
-
 }

--- a/view/tree2/class/props.ts
+++ b/view/tree2/class/props.ts
@@ -8,12 +8,17 @@ namespace $ {
 	) {
 		let props = this.$mol_view_tree2_class_super( klass )
 		
-		// ! syntax to *
+		// ! syntax to * and ?val syntax to ?
 		props = props.clone(
 			props.hack({
 				'': ( node, belt )=> {
-					const normal = node.type.replace( /!\w+/, '*' )
+					const next = node.type.indexOf('?')
+					const id = node.type.indexOf('!')
+					let normal = node.type
+					if (next !== -1) normal = normal.substring(0, next + 1)
+					if (id !== -1) normal = `${normal.substring(0, id)}*${next === -1 ? '' : '?'}`
 					if( node.type === normal ) return [ node.clone( node.hack( belt ) ) ]
+					console.warn(`Syntax ${node.type} is deprecated. Use ${normal} instead`)
 					return [ node.struct( normal, node.hack( belt ) ) ]
 				}
 			})
@@ -49,7 +54,6 @@ namespace $ {
 			},
 
 			'': (left, belt, context) => {
-				deprecated.call(this, left)
 				bindings.call(this, left)
 
 				let right
@@ -85,15 +89,6 @@ namespace $ {
 		for (const prop of props_root ) add_inner(prop)
 		
 		return Object.values(props_inner)
-	}
-
-	function deprecated(this: $, input: $mol_tree2) {
-		const writable = input.type.indexOf('?')
-		const param = input.type.indexOf('!')
-		let normalized = input.type
-		if (writable !== -1) normalized = normalized.substring(0, writable + 1)
-		if (param !== -1) normalized = `${normalized.substring(0, param)}*${writable === -1 ? '' : '?'}`
-		if (normalized !== input.type) console.warn(`Syntax ${input.type} is deprecated. Use ${normalized} instead`)
 	}
 
 	const is_writable = (input: $mol_tree2) => input.type.includes('?')

--- a/view/tree2/class/props.ts
+++ b/view/tree2/class/props.ts
@@ -98,4 +98,5 @@ namespace $ {
 		
 		return Object.values(props_inner)
 	}
+
 }

--- a/view/tree2/class/props.ts
+++ b/view/tree2/class/props.ts
@@ -49,6 +49,9 @@ namespace $ {
 			},
 
 			'': (left, belt, context) => {
+				deprecated.call(this, left)
+				bindings.call(this, left)
+
 				let right
 				const operator = left.kids[0]
 
@@ -82,6 +85,39 @@ namespace $ {
 		for (const prop of props_root ) add_inner(prop)
 		
 		return Object.values(props_inner)
+	}
+
+	function deprecated(this: $, input: $mol_tree2) {
+		const writable = input.type.indexOf('?')
+		const param = input.type.indexOf('!')
+		let normalized = input.type
+		if (writable !== -1) normalized = normalized.substring(0, writable + 1)
+		if (param !== -1) normalized = `${normalized.substring(0, param)}*${writable === -1 ? '' : '?'}`
+		if (normalized !== input.type) console.warn(`Syntax ${input.type} is deprecated. Use ${normalized} instead`)
+	}
+
+	const is_writable = (input: $mol_tree2) => input.type.includes('?')
+	function ensure_writable(this: $, input?: $mol_tree2) {
+		if (input && !is_writable(input)) this.$mol_fail(err`Expected writable at ${input.span}`)
+	}
+	function ensure_readonly(this: $, input?: $mol_tree2) {
+		if (input && is_writable(input)) this.$mol_fail(err`Expected readonly at ${input.span}`)
+	}
+	function bindings(this: $, left: $mol_tree2) {
+		const operator = left.kids[0]
+		switch (operator?.type) {
+			case '<=>':
+				ensure_writable.call(this, left)
+				ensure_writable.call(this, operator.kids[0])
+				break
+			case '=>':
+				const right = operator.kids[0]
+				if (right && is_writable(left) !== is_writable(right)) this.$mol_fail(err`Left and right operands are not compatible at ${operator.span}`)
+				break
+			case '<=':
+				ensure_readonly.call(this, left)
+				break
+		}
 	}
 
 }

--- a/view/tree2/class/props.ts
+++ b/view/tree2/class/props.ts
@@ -1,7 +1,6 @@
 namespace $ {
 	const err = $mol_view_tree2_error_str
 	type Context = { factory?: $mol_tree2 }
-
 	const is_writable = (input: $mol_tree2) => input.type.includes('?')
 
 	export function $mol_view_tree2_class_props(
@@ -56,7 +55,6 @@ namespace $ {
 			},
 
 			'': (left, belt, context) => {
-
 				let right
 				const operator = left.kids[0]
 

--- a/view/tree2/class/props.ts
+++ b/view/tree2/class/props.ts
@@ -16,8 +16,10 @@ namespace $ {
 					const next = node.type.indexOf('?')
 					const id = node.type.indexOf('!')
 					let normal = node.type
-					if (next !== -1) normal = normal.substring(0, next + 1)
-					if (id !== -1) normal = `${normal.substring(0, id)}*${next === -1 ? '' : '?'}`
+					const ch = node.type[id + 1]
+					if (id !== -1 && ch?.toUpperCase() !== ch?.toLowerCase())
+						normal = `${normal.substring(0, id)}*${next === -1 ? '' : '?'}`
+					else if (next !== -1) normal = normal.substring(0, next + 1)
 					if( node.type === normal ) return [ node.clone( node.hack( belt ) ) ]
 					console.warn(`Syntax ${node.type} is deprecated. Use ${normal} instead`)
 					return [ node.struct( normal, node.hack( belt ) ) ]

--- a/view/tree2/classes.ts
+++ b/view/tree2/classes.ts
@@ -1,47 +1,7 @@
 namespace $ {
-	const err = $mol_view_tree2_error_str
-	export function $mol_view_tree2_classes(defs: $mol_tree2) {
-		return defs.clone(
-			defs.hack({
-				'-': () => [],
-				'': (input, belt) => {
-					deprecated(input)
-					bindings(input)
-					return [input.clone(input.hack(belt))]
-				},
-			}),
-		)
-	}
-
-	function deprecated(input: $mol_tree2) {
-		const writable = input.type.indexOf('?')
-		const param = input.type.indexOf('!')
-		let normalized = input.type
-		if (writable !== -1) normalized = normalized.substring(0, writable + 1)
-		if (param !== -1) normalized = `${normalized.substring(0, param)}*${writable === -1 ? '' : '?'}`
-		if (normalized !== input.type) console.warn(`Syntax ${input.type} is deprecated. Use ${normalized} instead`)
-	}
-
-	const is_writable = (input: $mol_tree2) => input.type.includes('?')
-	function ensure_writable(input?: $mol_tree2) {
-		if (input && !is_writable(input)) return $mol_fail(err`Expected writable at ${input.span}`)
-	}
-	function ensure_readonly(input?: $mol_tree2) {
-		if (input && is_writable(input)) return $mol_fail(err`Expected readonly at ${input.span}`)
-	}
-	function bindings(input: $mol_tree2) {
-		const kid = input.kids[0]
-		switch (kid?.type) {
-			case '<=>':
-				ensure_writable(input)
-				ensure_writable(kid.kids[0])
-				break
-			case '=>':
-				;(is_writable(input) ? ensure_writable : ensure_readonly)(kid.kids[0])
-				break
-			case '<=':
-				ensure_readonly(input)
-				break
-		}
+	export function $mol_view_tree2_classes( defs : $mol_tree2 ) {
+		return defs.clone(defs.hack({
+			'-': () => []
+		}))
 	}
 }

--- a/view/tree2/classes.ts
+++ b/view/tree2/classes.ts
@@ -1,5 +1,27 @@
 namespace $ {
 	const err = $mol_view_tree2_error_str
+	export function $mol_view_tree2_classes(defs: $mol_tree2) {
+		return defs.clone(
+			defs.hack({
+				'-': () => [],
+				'': (input, belt) => {
+					deprecated(input)
+					bindings(input)
+					return [input.clone(input.hack(belt))]
+				},
+			}),
+		)
+	}
+
+	function deprecated(input: $mol_tree2) {
+		const writable = input.type.indexOf('?')
+		const param = input.type.indexOf('!')
+		let normalized = input.type
+		if (writable !== -1) normalized = normalized.substring(0, writable + 1)
+		if (param !== -1) normalized = `${normalized.substring(0, param)}*${writable === -1 ? '' : '?'}`
+		if (normalized !== input.type) console.warn(`Syntax ${input.type} is deprecated. Use ${normalized} instead`)
+	}
+
 	const is_writable = (input: $mol_tree2) => input.type.includes('?')
 	function ensure_writable(input?: $mol_tree2) {
 		if (input && !is_writable(input)) return $mol_fail(err`Expected writable at ${input.span}`)
@@ -7,27 +29,19 @@ namespace $ {
 	function ensure_readonly(input?: $mol_tree2) {
 		if (input && is_writable(input)) return $mol_fail(err`Expected readonly at ${input.span}`)
 	}
-	export function $mol_view_tree2_classes(defs: $mol_tree2) {
-		return defs.clone(
-			defs.hack({
-				'-': () => [],
-				'': (input, belt) => {
-					const kid = input.kids[0]
-					switch (kid?.type) {
-						case '<=>':
-							ensure_writable(input)
-							ensure_writable(kid.kids[0])
-							break
-						case '=>':
-							;(is_writable(input) ? ensure_writable : ensure_readonly)(kid.kids[0])
-							break
-						case '<=':
-							ensure_readonly(input)
-							break
-					}
-					return [input.clone(input.hack(belt))]
-				},
-			}),
-		)
+	function bindings(input: $mol_tree2) {
+		const kid = input.kids[0]
+		switch (kid?.type) {
+			case '<=>':
+				ensure_writable(input)
+				ensure_writable(kid.kids[0])
+				break
+			case '=>':
+				;(is_writable(input) ? ensure_writable : ensure_readonly)(kid.kids[0])
+				break
+			case '<=':
+				ensure_readonly(input)
+				break
+		}
 	}
 }

--- a/view/tree2/classes.ts
+++ b/view/tree2/classes.ts
@@ -1,7 +1,30 @@
 namespace $ {
-	export function $mol_view_tree2_classes( defs : $mol_tree2 ) {
-		return defs.clone(defs.hack({
-			'-': () => []
-		}))
+	const to_writable = (i: $mol_tree2, kids?: readonly $mol_tree2[]) =>
+		i.type.includes('?') ? i.clone(kids ?? i.kids) : i.struct(i.type + '?', kids ?? i.kids)
+
+	const bidi = (left: $mol_tree2, right: $mol_tree2) =>
+		to_writable(left, [(left.kids[0] ?? left).struct('<=>', [to_writable(right)])])
+
+	export function $mol_view_tree2_classes(defs: $mol_tree2) {
+		return defs.clone(
+			defs.hack({
+				'-': () => [],
+				'': (input, belt, context) => {
+					const kid = input.kids[0]
+					switch (kid?.type) {
+						case '<=>':
+							return [bidi(input, kid.hack(belt)[0])]
+						case '=>': {
+							const index = input.type.indexOf('?')
+							if (index !== -1) {
+								if (kid.kids[0]?.type?.includes('?')) return [bidi(input, kid.hack(belt)[0])]
+								else return [input.struct(input.type.substring(0, index), input.hack(belt))]
+							}
+						}
+					}
+					return [input.clone(input.hack(belt))]
+				},
+			}),
+		)
 	}
 }

--- a/view/tree2/classes.ts
+++ b/view/tree2/classes.ts
@@ -1,26 +1,29 @@
 namespace $ {
-	const to_writable = (i: $mol_tree2, kids?: readonly $mol_tree2[]) =>
-		i.type.includes('?') ? i.clone(kids ?? i.kids) : i.struct(i.type + '?', kids ?? i.kids)
-
-	const bidi = (left: $mol_tree2, right: $mol_tree2) =>
-		to_writable(left, [(left.kids[0] ?? left).struct('<=>', [to_writable(right)])])
-
+	const err = $mol_view_tree2_error_str
+	const is_writable = (input: $mol_tree2) => input.type.includes('?')
+	function ensure_writable(input?: $mol_tree2) {
+		if (input && !is_writable(input)) return $mol_fail(err`Expected writable at ${input.span}`)
+	}
+	function ensure_readonly(input?: $mol_tree2) {
+		if (input && is_writable(input)) return $mol_fail(err`Expected readonly at ${input.span}`)
+	}
 	export function $mol_view_tree2_classes(defs: $mol_tree2) {
 		return defs.clone(
 			defs.hack({
 				'-': () => [],
-				'': (input, belt, context) => {
+				'': (input, belt) => {
 					const kid = input.kids[0]
 					switch (kid?.type) {
 						case '<=>':
-							return [bidi(input, kid.hack(belt)[0])]
-						case '=>': {
-							const index = input.type.indexOf('?')
-							if (index !== -1) {
-								if (kid.kids[0]?.type?.includes('?')) return [bidi(input, kid.hack(belt)[0])]
-								else return [input.struct(input.type.substring(0, index), input.hack(belt))]
-							}
-						}
+							ensure_writable(input)
+							ensure_writable(kid.kids[0])
+							break
+						case '=>':
+							;(is_writable(input) ? ensure_writable : ensure_readonly)(kid.kids[0])
+							break
+						case '<=':
+							ensure_readonly(input)
+							break
 					}
 					return [input.clone(input.hack(belt))]
 				},

--- a/view/tree2/to/js/test/js.bidi.test.ts
+++ b/view/tree2/to/js/test/js.bidi.test.ts
@@ -153,13 +153,13 @@ namespace $ {
 				$mol_view_tree2_to_js_test_run(`
 					Foo $mol_view
 						a!? $mol_view
-							expanded <=> cell_test_expanded!? null
+							expanded? <=> cell_test_expanded!? null
 				`)
-			}, `Required prop like some*? at \`.view.tree#4:21/20\`
+			}, `Required prop like some*? at \`.view.tree#4:22/20\`
 <=>
-.view.tree#4:17/3
-expanded
-.view.tree#4:8/8
+.view.tree#4:18/3
+expanded?
+.view.tree#4:8/9
 $mol_view
 .view.tree#3:11/9
 a!?


### PR DESCRIPTION
1 `foo <=> bar` -> требует заменить на `foo?` и `bar?`
2 `foo? => bar` и `foo => bar?` -> ошибка: `Left and right operands are not compatible at ${op.span}`
3 `foo? <= bar` -> требует заменить на `foo`
4 `foo!id?val` -> предупреждение: `Syntax foo!id?val is deprecated. Use foo*? instead`

Подвязался к `$mol_view_tree2_class_props`